### PR TITLE
feat: Phase 4c — blog pages with Storyblok (migrated to Vite)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Storyblok GraphQL API token
+# Rename from NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN if migrating from Next.js
+VITE_STORYBLOK_ACCESS_TOKEN=
+
+# Google Analytics tracking ID (optional)
+VITE_GA_TRACKING_ID=

--- a/src/components/layouts/blog-post-layout.tsx
+++ b/src/components/layouts/blog-post-layout.tsx
@@ -29,7 +29,7 @@ export function BlogPostLayout({ post }: Props) {
           </header>
           <div
             className="prose dark:prose-invert max-w-none [&_img]:max-w-full"
-            dangerouslySetInnerHTML={{ __html: body }}
+            dangerouslySetInnerHTML={{ __html: body ?? '' }}
           />
         </article>
       </Container>

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -1,4 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { BlogPostLayout } from '@/components/layouts/blog-post-layout';
+import { getPostBySlug } from '@/services/storyblok';
 
 export const Route = createFileRoute('/blog/$slug')({
   component: BlogPostPage,
@@ -6,5 +10,18 @@ export const Route = createFileRoute('/blog/$slug')({
 
 function BlogPostPage() {
   const { slug } = Route.useParams();
-  return <div>Blog post: {slug} — coming soon</div>;
+
+  const {
+    data: post,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['post', slug],
+    queryFn: () => getPostBySlug(slug),
+  });
+
+  if (isPending) return null;
+  if (isError) return <p>Failed to load post. Please try again later.</p>;
+
+  return <BlogPostLayout post={post} />;
 }

--- a/src/routes/blog/index.tsx
+++ b/src/routes/blog/index.tsx
@@ -1,9 +1,25 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { BlogLayout } from '@/components/layouts/blog-layout';
+import { getAllPosts } from '@/services/storyblok';
 
 export const Route = createFileRoute('/blog/')({
   component: BlogPage,
 });
 
 function BlogPage() {
-  return <div>Blog — coming soon</div>;
+  const {
+    data: posts = [],
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['posts'],
+    queryFn: getAllPosts,
+  });
+
+  if (isPending) return null;
+  if (isError) return <p>Failed to load posts. Please try again later.</p>;
+
+  return <BlogLayout posts={posts} />;
 }

--- a/src/services/storyblok.ts
+++ b/src/services/storyblok.ts
@@ -1,129 +1,87 @@
-import Storyblok, { Richtext } from 'storyblok-js-client';
+import StoryblokClient, { type ISbRichtext } from 'storyblok-js-client';
 
-/**
- * RichText resolver
- */
+import { type Post } from '@/types/storyblok';
 
-const client = new Storyblok({
-  accessToken: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
+const client = new StoryblokClient({
+  accessToken: import.meta.env.VITE_STORYBLOK_ACCESS_TOKEN,
 });
 
-export const renderRichText = (richText: Richtext): string =>
+export const renderRichText = (richText: ISbRichtext): string =>
   client.richTextResolver.render(richText);
 
-/**
- * API
- */
-
-export type Post = {
-  content: {
-    date: number | Date;
-    language: 'pt-br' | 'en';
-    slug: string;
-    title: string;
-    banner: {
-      alt: string;
-      filename: string;
-    };
-    body: Richtext;
-  };
+// Internal type — raw shape returned by the GraphQL API (body is ISbRichtext, not rendered HTML)
+type RawPost = {
+  content: Omit<Post['content'], 'body'> & { body: ISbRichtext };
 };
 
-type Options = {
-  variables?: Record<string, any>;
-  preview?: boolean;
-};
-
-async function fetchAPI(query: string, { variables, preview = false }: Options = {}) {
+async function fetchAPI(query: string, variables?: Record<string, unknown>) {
   const res = await fetch('https://gapi.storyblok.com/v1/api', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Token: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
-      Version: preview ? 'draft' : 'published',
-    } as any,
-    body: JSON.stringify({
-      query,
-      variables,
-    }),
+      Token: import.meta.env.VITE_STORYBLOK_ACCESS_TOKEN,
+      Version: 'published',
+    },
+    body: JSON.stringify({ query, variables }),
   });
 
-  const json = await res.json();
-  if (json.errors) {
-    console.error(json.errors);
-    throw new Error('Failed to fetch API');
-  }
+  const json = (await res.json()) as { data?: unknown; errors?: unknown };
+  if (json.errors) throw new Error('Failed to fetch Storyblok API');
 
   return json.data;
 }
 
-const PostFragment = `
-	content {
-		title
-		slug
-		date
-		language
-		banner {
-			filename,
-			alt
-		}
-		body
-	}
-`;
-
-export async function getAllPosts(): Promise<Array<Post>> {
-  const data = await fetchAPI(
-    `
+export async function getAllPosts(): Promise<Post[]> {
+  const data = await fetchAPI(`
     {
       PostItems(sort_by: "created_at:desc") {
         items {
-					content {
-						title
-						slug
-						date
-						language
-						banner {
-							filename,
-							alt
-						}
-					}
-        }
-      }
-    }
-  `,
-  );
-
-  return data?.PostItems.items;
-}
-
-export async function getAllPostsSlug(): Promise<Array<{ slug: string }>> {
-  const data = await fetchAPI(`
-    {
-      PostItems {
-        items {
-          slug
+          content {
+            title
+            slug
+            date
+            language
+            banner {
+              filename
+              alt
+            }
+          }
         }
       }
     }
   `);
-  return data?.PostItems.items;
+
+  return (data as { PostItems: { items: Post[] } }).PostItems.items;
 }
 
 export async function getPostBySlug(slug: string): Promise<Post> {
   const data = await fetchAPI(
     `
-  query PostBySlug($slug: ID!) {
-    PostItem(id: $slug) {
-      ${PostFragment}
+    query PostBySlug($slug: ID!) {
+      PostItem(id: $slug) {
+        content {
+          title
+          slug
+          date
+          language
+          banner {
+            filename
+            alt
+          }
+          body
+        }
+      }
     }
-  }
   `,
-    {
-      variables: {
-        slug: `post/${slug}`,
-      },
-    },
+    { slug: `post/${slug}` },
   );
 
-  return data?.PostItem;
+  const raw = (data as { PostItem: RawPost }).PostItem;
+
+  return {
+    content: {
+      ...raw.content,
+      body: renderRichText(raw.content.body),
+    },
+  };
 }

--- a/src/types/storyblok.ts
+++ b/src/types/storyblok.ts
@@ -8,6 +8,6 @@ export type Post = {
       alt: string;
       filename: string;
     };
-    body: string; // pre-rendered HTML from renderRichText
+    body?: string; // pre-rendered HTML from renderRichText (absent on listing)
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
   },
   "include": ["src", "vite-env.d.ts"],
   "exclude": [
-    "node_modules",
-    "src/services/storyblok.ts"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
## Summary

### Storyblok service rewrite (`src/services/storyblok.ts`)
- `process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN` → `import.meta.env.VITE_STORYBLOK_ACCESS_TOKEN`
- `Richtext` → `ISbRichtext` (storyblok-js-client v6 API)
- Removed `preview` mode (SPA always serves published content)
- `getPostBySlug` now calls `renderRichText` internally, returning a clean `Post` with `body: string`
- Strict response typing; `console.error` removed (0 lint warnings now)

### Blog routes
| Route | Query key | Data source |
|-------|-----------|-------------|
| `/blog` | `['posts']` | `getAllPosts()` |
| `/blog/$slug` | `['post', slug]` | `getPostBySlug(slug)` |

### Other changes
- `src/types/storyblok.ts` — `body` made optional (listing queries don't fetch body)
- `blog-post-layout.tsx` — `body ?? ''` guards against optional body
- `tsconfig.json` — `src/services/storyblok.ts` removed from exclude (now fully typed)
- `.env.example` — documents required env vars

> **⚠️ Action required:** Rename `NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN` → `VITE_STORYBLOK_ACCESS_TOKEN` in your `.env` / deployment env vars.

> Depends on `feat/component-migration` (#27) for `BlogLayout`, `BlogPostLayout`, and `src/types/storyblok.ts`.

## Test plan

- [ ] `pnpm build` ✅ · `pnpm lint` ✅ (0 warnings) · `pnpm format:check` ✅ · `pnpm test` ✅
- [ ] Set `VITE_STORYBLOK_ACCESS_TOKEN` in `.env` and run `pnpm dev`
- [ ] `/blog` fetches and renders post listing from Storyblok
- [ ] Each post card shows banner image, language flag, title, date
- [ ] Clicking a card navigates to `/blog/<slug>`
- [ ] `/blog/<slug>` fetches and renders full post with rich text
- [ ] ThemeSelector visible and functional on both blog pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)